### PR TITLE
instead of using system.io.file.readallbytes to write the file into t…

### DIFF
--- a/src/EPPlus.Core/ExcelPackage.cs
+++ b/src/EPPlus.Core/ExcelPackage.cs
@@ -546,8 +546,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    byte[] b = System.IO.File.ReadAllBytes(template.FullName);
-                    ms.Write(b, 0, b.Length);
+                    WriteFileToStream(template.FullName, ms);
                 }
                 try
                 {
@@ -597,8 +596,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    byte[] b = System.IO.File.ReadAllBytes(File.FullName);
-                    ms.Write(b, 0, b.Length);
+                    WriteFileToStream(File.FullName, ms);
                 }
                 try
                 {
@@ -627,6 +625,24 @@ namespace OfficeOpenXml
                 //_package = Package.Open(_stream, FileMode.Create, FileAccess.ReadWrite);
                 _package = new Packaging.ZipPackage(ms);
                 CreateBlankWb();
+            }
+        }
+
+        /// <summary>
+        /// Writes given file to stream
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="stream"></param>
+        private void WriteFileToStream(string path, Stream stream)
+        {
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            {
+                var buffer = new byte[4096];
+                int read;
+                while ((read = fileStream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    stream.Write(buffer, 0, read);
+                }
             }
         }
 


### PR DESCRIPTION
…he buffer, use repeated reads with correct file access options.

(http://epplus.codeplex.com/SourceControl/network/forks/perkuypers/EPPlusReadExcelWhenOpened/changeset/6c7e7a5fd368)